### PR TITLE
Update UserAgentCss.cs

### DIFF
--- a/itext/itext.html2pdf/itext/html2pdf/css/resolve/UserAgentCss.cs
+++ b/itext/itext.html2pdf/itext/html2pdf/css/resolve/UserAgentCss.cs
@@ -65,7 +65,7 @@ namespace iText.Html2pdf.Css.Resolve {
         static UserAgentCss() {
             CssStyleSheet parsedStylesheet = new CssStyleSheet();
             try {
-                parsedStylesheet = CssStyleSheetParser.Parse(ResourceUtil.GetResourceStream(DEFAULT_CSS_PATH));
+                parsedStylesheet = CssStyleSheetParser.Parse(ResourceUtil.GetResourceStream(DEFAULT_CSS_PATH, typeof(UserAgentCss)));
             }
             catch (Exception exc) {
                 ILog logger = LogManager.GetLogger(typeof(UserAgentCss));


### PR DESCRIPTION
We experienced that when upgrading our pdf solution in Azure from Functions v1 (.NET 4.x) to v3 (.NET Core 3.1) we lost all styling from html content.

The solution was to fix the resource resolution affecting UserAgentCss, which we solved with the following:
`ResourceUtil.AddToResourceSearch(typeof(HtmlConverter).Assembly);`

The proposed fix in this PR is untested, since we are happy with our current fix.
However it would be nice if this got fixed in upstream as well.
