### PR TITLE
feat: resolve css variables

### DIFF
--- a/itext.tests/itext.html2pdf.tests/itext/html2pdf/css/CssStylesResolvingTest.cs
+++ b/itext.tests/itext.html2pdf.tests/itext/html2pdf/css/CssStylesResolvingTest.cs
@@ -191,6 +191,22 @@ namespace iText.Html2pdf.Css {
                 , "font-family: times");
         }
 
+        [NUnit.Framework.TestCase("cssVariablesTest01.html", "30px", "30px")]
+        [NUnit.Framework.TestCase("cssVariablesTest02.html", "50px", "30px")]
+        [NUnit.Framework.TestCase("cssVariablesTest03.html", "35px", "35px")]
+        public virtual void CssVariablesTest1(string fileName, string expectedMargin, string expectedVarValue) {
+            Test(fileName, "html body div",
+                "display: block",
+                $"--test-var: {expectedVarValue}",
+                $"margin-top: {expectedMargin}",
+                $"margin-right: {expectedMargin}",
+                $"margin-bottom: {expectedMargin}",
+                $"margin-left: {expectedMargin}",
+                "font-family: times",
+                "font-size: 12pt"
+                );
+        }
+
         private void ResolveStylesForTree(INode node, ICssResolver cssResolver, CssContext context) {
             if (node is IElementNode) {
                 IElementNode element = (IElementNode)node;

--- a/itext.tests/itext.html2pdf.tests/resources/itext/html2pdf/css/CssElementStylesResolvingTest/cssVariablesTest01.html
+++ b/itext.tests/itext.html2pdf.tests/resources/itext/html2pdf/css/CssElementStylesResolvingTest/cssVariablesTest01.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+    <style type="text/css">
+    div {
+        --test-var: 30px;
+    }
+
+        div.a {
+            margin: var(--test-var,40px);
+        }
+
+        div.b {
+            margin: var(--other-var,50px);
+        }
+
+        div.c {
+            --test-var: 35px;
+        }
+
+            div.c.d {
+                margin: var(--test-var,40px);
+            }
+</style>
+</head>
+<body>
+    <div class="a">
+        This is a div text with margin 30px
+    </div>
+</body>
+</html>

--- a/itext.tests/itext.html2pdf.tests/resources/itext/html2pdf/css/CssElementStylesResolvingTest/cssVariablesTest02.html
+++ b/itext.tests/itext.html2pdf.tests/resources/itext/html2pdf/css/CssElementStylesResolvingTest/cssVariablesTest02.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+    <style type="text/css">
+    div {
+        --test-var: 30px;
+    }
+
+        div.a {
+            margin: var(--test-var,40px);
+        }
+
+        div.b {
+            margin: var(--other-var,50px);
+        }
+
+        div.c {
+            --test-var: 35px;
+        }
+
+            div.c.d {
+                margin: var(--test-var,40px);
+            }
+</style>
+</head>
+<body>
+    <div class="b">
+        This is a div text with margin 50px
+    </div>
+</body>
+</html>

--- a/itext.tests/itext.html2pdf.tests/resources/itext/html2pdf/css/CssElementStylesResolvingTest/cssVariablesTest03.html
+++ b/itext.tests/itext.html2pdf.tests/resources/itext/html2pdf/css/CssElementStylesResolvingTest/cssVariablesTest03.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+    <style type="text/css">
+    div {
+        --test-var: 30px;
+    }
+
+        div.a {
+            margin: var(--test-var,40px);
+        }
+
+        div.b {
+            margin: var(--other-var,50px);
+        }
+
+        div.c {
+            --test-var: 35px;
+        }
+
+            div.c.d {
+                margin: var(--test-var,40px);
+            }
+</style>
+</head>
+<body>
+    <div class="c d">
+        This is a div text with margin 35px
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Current style sheet logic ignores CSS variables, and can break when parsing them.

This PR properly resolves CSS variables.
